### PR TITLE
Fix grammar in README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # is-audio
-Check if a filepath is a audio file
+Check if a file path is an audio file
 
 ## Install
 


### PR DESCRIPTION
## Summary
- correct grammar of README description

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685546e6128c832084cb3c0a24d75c31